### PR TITLE
TASK-56 – CRUD de Códigos de E-mail (OTP para Login Admin)

### DIFF
--- a/src/main/java/utfpr/edu/br/coleta/email/EmailCode.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/EmailCode.java
@@ -1,0 +1,81 @@
+package utfpr.edu.br.coleta.email;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+import utfpr.edu.br.coleta.generics.BaseEntity;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entidade que representa um código temporário enviado por e-mail,
+ * utilizado em processos de autenticação, cadastro e recuperação de senha.
+ *
+ * Autor: Luiz Alberto
+ */
+@Entity
+@Table(name = "tb_access_code")
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmailCode extends BaseEntity {
+
+  /** Endereço de e-mail do destinatário ao qual o código está vinculado. */
+  @Column(nullable = false)
+  @Email(message = "E-mail deve ter formato válido.")
+  @NotBlank(message = "O e-mail é obrigatório.")
+  private String email;
+
+  /** Código de validação gerado e enviado ao usuário. */
+  @NotBlank(message = "O código é obrigatório.")
+  @Column(nullable = false, unique = true)
+  private String code;
+
+  /** Data e hora em que o código foi gerado. */
+  @NotNull(message = "A data de geração é obrigatória.")
+  @Column(name = "generated_at", nullable = false)
+  private LocalDateTime generatedAt;
+
+  /** Indica se o código já foi utilizado. */
+  @Column(nullable = false)
+  private boolean used = false;
+
+  /** Data e hora de expiração do código. */
+  @NotNull(message = "A data de expiração é obrigatória.")
+  @Column(nullable = false)
+  private LocalDateTime expiration;
+
+  /** Tipo do código de validação (autenticação, cadastro, recuperação, etc). */
+  @NotNull(message = "O tipo do código é obrigatório.")
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private TipoCodigo type;
+
+  /**
+   * Construtor para instanciar um novo código de validação de e-mail.
+   *
+   * @param email endereço de e-mail do destinatário
+   * @param code código de validação gerado
+   * @param generatedAt data e hora da geração do código
+   * @param expiration data e hora de expiração do código
+   * @param type tipo do código de validação
+   */
+  public EmailCode(
+          String email,
+          String code,
+          LocalDateTime generatedAt,
+          LocalDateTime expiration,
+          TipoCodigo type) {
+    this.email = email;
+    this.code = code;
+    this.generatedAt = generatedAt;
+    this.expiration = expiration;
+    this.type = type;
+    this.used = false;
+  }
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/EmailCodeDto.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/EmailCodeDto.java
@@ -1,0 +1,115 @@
+package utfpr.edu.br.coleta.email;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO para transferência de dados da entidade {@link EmailCode}.
+ * Representa as informações necessárias para criação, validação e uso de códigos de e-mail (OTP).
+ *
+ * Autor: Luiz Alberto dos Passos
+ */
+public class EmailCodeDto {
+
+  /** Identificador único do código de e-mail. */
+  private Long id;
+
+  /** Endereço de e-mail associado ao código. */
+  @NotBlank(message = "O e-mail é obrigatório.")
+  @Email(message = "E-mail inválido.")
+  private String email;
+
+  /** Código gerado para validação. */
+  @NotBlank(message = "O código é obrigatório.")
+  private String code;
+
+  /** Tipo do código (cadastro, autenticação, recuperação, etc.). */
+  @NotNull(message = "O tipo do código é obrigatório.")
+  private TipoCodigo type;
+
+  /** Indica se o código já foi utilizado. */
+  @NotNull(message = "O status de uso é obrigatório.")
+  private Boolean used;
+
+  /** Data e hora em que o código foi gerado. */
+  @NotNull(message = "A data de geração é obrigatória.")
+  private LocalDateTime generatedAt;
+
+  /** Data e hora em que o código expira. */
+  @NotNull(message = "A data de expiração é obrigatória.")
+  private LocalDateTime expiration;
+
+  /** Retorna o identificador único do código de e-mail. */
+  public Long getId() {
+    return id;
+  }
+
+  /** Define o identificador do código de e-mail. */
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  /** Retorna o endereço de e-mail associado ao código. */
+  public String getEmail() {
+    return email;
+  }
+
+  /** Define o endereço de e-mail associado ao código. */
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  /** Retorna o código associado ao e-mail. */
+  public String getCode() {
+    return code;
+  }
+
+  /** Define o valor do código associado ao e-mail. */
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  /** Obtém o tipo ou categoria do código de e-mail. */
+  public TipoCodigo getType() {
+    return type;
+  }
+
+  /** Define o tipo ou categoria associado ao código de e-mail. */
+  public void setType(TipoCodigo type) {
+    this.type = type;
+  }
+
+  /** Retorna se o código já foi utilizado. */
+  public Boolean getUsed() {
+    return used;
+  }
+
+  /** Define se o código foi utilizado. */
+  public void setUsed(Boolean used) {
+    this.used = used;
+  }
+
+  /** Retorna a data e hora em que o código foi gerado. */
+  public LocalDateTime getGeneratedAt() {
+    return generatedAt;
+  }
+
+  /** Define a data e hora em que o código foi gerado. */
+  public void setGeneratedAt(LocalDateTime generatedAt) {
+    this.generatedAt = generatedAt;
+  }
+
+  /** Retorna a data e hora de expiração do código de e-mail. */
+  public LocalDateTime getExpiration() {
+    return expiration;
+  }
+
+  /** Define a data e hora de expiração do código. */
+  public void setExpiration(LocalDateTime expiration) {
+    this.expiration = expiration;
+  }
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/EmailCodeRepository.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/EmailCodeRepository.java
@@ -1,0 +1,45 @@
+package utfpr.edu.br.coleta.email;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * Repositório responsável pelas operações de persistência e consulta
+ * da entidade {@link EmailCode}.
+ *
+ * Autor: Luiz Alberto dos Passos
+ */
+public interface EmailCodeRepository extends JpaRepository<EmailCode, Long> {
+
+  /**
+   * Busca o código mais recente para o e-mail e tipo informados.
+   *
+   * @param email endereço de e-mail
+   * @param type tipo do código
+   * @return código mais recente, se existir
+   */
+  Optional<EmailCode> findTopByEmailAndTypeOrderByGeneratedAtDesc(String email, TipoCodigo type);
+
+  /**
+   * Retorna um código válido que ainda não expirou e não foi utilizado.
+   *
+   * @param code valor do código
+   * @param now data e hora limite para expiração
+   * @return código válido, se encontrado
+   */
+  Optional<EmailCode> findByCodeAndExpirationAfterAndUsedFalse(String code, LocalDateTime now);
+
+  /**
+   * Conta quantos códigos foram gerados após a data especificada.
+   *
+   * @param email endereço de e-mail
+   * @param type tipo do código
+   * @param generatedAt data e hora mínima
+   * @return quantidade de códigos encontrados
+   */
+  Long countByEmailAndTypeAndGeneratedAtAfter(
+          String email, TipoCodigo type, LocalDateTime generatedAt);
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/EmailCodeValidationService.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/EmailCodeValidationService.java
@@ -1,0 +1,59 @@
+package utfpr.edu.br.coleta.email;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+
+import java.time.LocalDateTime;
+
+/**
+ * Serviço responsável por validar códigos enviados por e-mail.
+ *
+ * Autor: Luiz Alberto dos Passos
+ */
+@Service
+public class EmailCodeValidationService {
+
+    /** Repositório para acesso e manipulação de códigos de e-mail. */
+    private final EmailCodeRepository repository;
+
+    /**
+     * Construtor que cria uma instância do serviço de validação.
+     *
+     * @param repository repositório de códigos de e-mail
+     */
+    public EmailCodeValidationService(EmailCodeRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Valida se o código informado é o mais recente para o e-mail e tipo especificados.
+     *
+     * Verifica:
+     * - Se o código corresponde ao último gerado.
+     * - Se ainda não foi utilizado.
+     * - Se está dentro do prazo de validade.
+     *
+     * Caso válido, o código é marcado como utilizado e salvo.
+     *
+     * @param email e-mail associado ao código
+     * @param type tipo do código (ex: cadastro, recuperação)
+     * @param code valor do código informado
+     * @return true se válido e marcado como usado, false caso contrário
+     */
+    @Transactional
+    public boolean validateCode(String email, TipoCodigo type, String code) {
+        return repository
+                .findTopByEmailAndTypeOrderByGeneratedAtDesc(email, type)
+                .filter(ec -> ec.getCode().equals(code))
+                .filter(ec -> !ec.isUsed())
+                .filter(ec -> ec.getExpiration().isAfter(LocalDateTime.now()))
+                .map(
+                        ec -> {
+                            ec.setUsed(true);
+                            repository.save(ec);
+                            return true;
+                        })
+                .orElse(false);
+    }
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/EmailConfig.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/EmailConfig.java
@@ -1,0 +1,33 @@
+package utfpr.edu.br.coleta.email;
+
+import com.sendgrid.SendGrid;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Classe de configuração responsável por expor o cliente {@link SendGrid}
+ * como um bean gerenciado pelo Spring.
+ *
+ * Autor: Luiz Alberto dos Passos
+ */
+@Configuration
+public class EmailConfig {
+
+  /**
+   * Chave de API utilizada para autenticação no serviço SendGrid.
+   * O valor é obtido das propriedades da aplicação.
+   */
+  @Value("${spring.sendgrid.api-key:sendgridkey}")
+  private String apiKey;
+
+  /**
+   * Cria um bean do cliente SendGrid configurado com a chave de API definida.
+   *
+   * @return instância configurada de {@link SendGrid}
+   */
+  @Bean
+  public SendGrid sendGrid() {
+    return new SendGrid(apiKey);
+  }
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/EmailController.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/EmailController.java
@@ -1,0 +1,158 @@
+package utfpr.edu.br.coleta.email;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+import utfpr.edu.br.coleta.email.impl.EmailServiceImpl;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Controlador responsável por expor endpoints REST para envio e validação
+ * de códigos de verificação por e-mail.
+ *
+ * Autor: Luiz Alberto dos Passos
+ */
+@Tag(name = "Email", description = "API para envio e validação de códigos por e-mail")
+@RestController
+@RequestMapping("/api/email")
+@Validated
+public class EmailController {
+
+  private final EmailServiceImpl emailService;
+  private final EmailCodeValidationService validationService;
+
+  /**
+   * Construtor que cria o controlador de e-mail com os serviços necessários.
+   *
+   * @param emailService serviço de envio de e-mails
+   * @param validationService serviço de validação de códigos
+   */
+  public EmailController(
+          EmailServiceImpl emailService, EmailCodeValidationService validationService) {
+    this.emailService = emailService;
+    this.validationService = validationService;
+  }
+
+  /**
+   * Envia um código de verificação para o e-mail informado.
+   *
+   * @param email endereço de e-mail do destinatário
+   * @param type tipo do código (valor do enum {@link TipoCodigo})
+   * @return resposta com mensagem de sucesso, e-mail e tipo do código
+   * @throws IllegalArgumentException se os parâmetros forem inválidos
+   * @throws IOException se ocorrer falha no envio do e-mail
+   */
+  @Operation(summary = "Envia código de verificação por e-mail")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "Código enviado com sucesso"),
+          @ApiResponse(responseCode = "400", description = "Parâmetros inválidos ou limite excedido"),
+          @ApiResponse(responseCode = "500", description = "Erro ao enviar e-mail")
+  })
+  @PostMapping("/enviar")
+  public ResponseEntity<Map<String, String>> enviar(
+          @RequestParam String email, @RequestParam String type) throws IOException {
+    validarEmail(email);
+    TipoCodigo tipoCodigo = converterParaTipoCodigo(type);
+    validarTipo(tipoCodigo);
+
+    emailService.generateAndSendCode(email, tipoCodigo);
+
+    return ResponseEntity.ok(
+            Map.of(
+                    "mensagem", "Código enviado com sucesso", "email", email, "tipo", tipoCodigo.name()));
+  }
+
+  /**
+   * Valida um código de verificação enviado ao e-mail informado.
+   *
+   * @param email endereço de e-mail
+   * @param type tipo do código
+   * @param code código recebido pelo usuário
+   * @return true se válido, false caso contrário
+   */
+  @Operation(summary = "Valida o código de verificação enviado")
+  @ApiResponse(responseCode = "200", description = "Validação realizada com sucesso")
+  @PostMapping("/validar")
+  public ResponseEntity<Boolean> validar(
+          @RequestParam @NotBlank @Email String email,
+          @RequestParam @NotBlank String type,
+          @RequestParam @NotBlank String code) {
+    TipoCodigo tipoCodigo = converterParaTipoCodigo(type);
+    boolean valido = validationService.validateCode(email, tipoCodigo, code);
+    return ResponseEntity.ok(valido);
+  }
+
+  /**
+   * Trata exceções de parâmetros inválidos e retorna HTTP 400.
+   *
+   * @param e exceção lançada
+   * @return resposta com mensagem de erro
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, String>> handleIllegalArgumentException(
+          IllegalArgumentException e) {
+    return ResponseEntity.badRequest().body(Map.of("erro", e.getMessage()));
+  }
+
+  /**
+   * Trata falhas no envio de e-mails e retorna HTTP 500.
+   *
+   * @param e exceção lançada
+   * @return resposta com mensagem de erro
+   */
+  @ExceptionHandler(IOException.class)
+  public ResponseEntity<Map<String, String>> handleIOException(IOException e) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(Map.of("erro", "Falha ao enviar e-mail: " + e.getMessage()));
+  }
+
+  /**
+   * Valida se o e-mail informado é válido.
+   *
+   * @param email e-mail a validar
+   */
+  private void validarEmail(String email) {
+    if (email == null || email.isBlank() || !email.matches("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
+      throw new IllegalArgumentException("Email inválido");
+    }
+  }
+
+  /**
+   * Valida se o tipo do código foi informado.
+   *
+   * @param type tipo a validar
+   */
+  private void validarTipo(TipoCodigo type) {
+    if (type == null) {
+      throw new IllegalArgumentException("Tipo de código não informado");
+    }
+  }
+
+  /**
+   * Converte uma string para {@link TipoCodigo}.
+   *
+   * @param type valor em string
+   * @return enum correspondente
+   */
+  private TipoCodigo converterParaTipoCodigo(String type) {
+    if (type == null || type.isBlank()) {
+      throw new IllegalArgumentException("Tipo de código não informado");
+    }
+
+    try {
+      return TipoCodigo.valueOf(type.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Tipo de código inválido: " + type);
+    }
+  }
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/enums/TipoCodigo.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/enums/TipoCodigo.java
@@ -1,0 +1,56 @@
+package utfpr.edu.br.coleta.email.enums;
+
+import lombok.Getter;
+
+/**
+ * Enum que representa os diferentes tipos de códigos utilizados no sistema
+ * para operações de autenticação, cadastro e recuperação de senha.
+ *
+ * <p>
+ * Cada constante possui um valor associado em {@link #tipo}, que descreve
+ * o contexto de uso do código.
+ * </p>
+ *
+ * Autor Luiz Alberto dos Passos
+ */
+@Getter
+public enum TipoCodigo {
+
+  /**
+   * Código OTP gerado para autenticação de login.
+   */
+  OTP_AUTENTICACAO("Autenticação"),
+
+  /**
+   * Código OTP gerado para confirmação de cadastro.
+   */
+  OTP_CADASTRO("Cadastro"),
+
+  /**
+   * Código OTP gerado para recuperação de senha.
+   */
+  OTP_RECUPERACAO("Recuperação de Senha");
+
+  /**
+   * Descrição textual do tipo de código.
+   */
+  private final String tipo;
+
+  /**
+   * Construtor que associa uma descrição textual ao tipo de código.
+   *
+   * @param tipo descrição do código (ex: "Autenticação", "Cadastro")
+   */
+  TipoCodigo(String tipo) {
+    this.tipo = tipo;
+  }
+
+  /**
+   * Retorna a descrição textual do tipo de código.
+   *
+   * @return string representando o tipo do código
+   */
+  public String getTipo() {
+    return tipo;
+  }
+}

--- a/src/main/java/utfpr/edu/br/coleta/email/impl/EmailServiceImpl.java
+++ b/src/main/java/utfpr/edu/br/coleta/email/impl/EmailServiceImpl.java
@@ -1,0 +1,221 @@
+package utfpr.edu.br.coleta.email.impl;
+
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import utfpr.edu.br.coleta.email.EmailCode;
+import utfpr.edu.br.coleta.email.EmailCodeRepository;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Serviço responsável por gerar códigos OTP, enviar e-mails utilizando SendGrid
+ * e registrar as informações no banco de dados.
+ *
+ * Autor: Luiz Alberto dos Passos
+ */
+@Service
+public class EmailServiceImpl {
+
+  /** Tempo de expiração de um código OTP em minutos. */
+  private static final int CODE_EXPIRATION_MINUTES = 10;
+
+  /** Limite máximo de códigos permitidos por e-mail em 24 horas. */
+  private static final int MAX_CODES_PER_DAY = 30;
+
+  /** Limite máximo de códigos permitidos em curto período. */
+  private static final int MAX_CODES_IN_SHORT_PERIOD = 5;
+
+  /** Intervalo de tempo em minutos para o limite de curto período. */
+  private static final int SHORT_PERIOD_REST_IN_MINUTES = 15;
+
+  /** Expressão regular para validação de formato de e-mail. */
+  private static final Pattern EMAIL_REGEX = Pattern.compile("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$");
+
+  /** Mensagem de erro quando o limite diário de códigos é atingido. */
+  public static final String ERRO_LIMITE_DIARIO =
+          "Quantidade de solicitações ultrapassa o limite das últimas 24 horas.";
+
+  /** Mensagem de erro quando o limite de curto período é atingido. */
+  public static final String ERRO_LIMITE_CURTO =
+          "Limite de solicitações atingido, tente novamente em %d minutos.";
+
+  /** Logger para registro de eventos e erros no serviço. */
+  private static final Logger logger = LoggerFactory.getLogger(EmailServiceImpl.class);
+
+  /** Repositório responsável pela persistência de códigos de e-mail. */
+  private final EmailCodeRepository repository;
+
+  /** Cliente SendGrid utilizado para envio de e-mails. */
+  private final SendGrid sendGrid;
+
+  /** Motor de templates Thymeleaf para geração de mensagens HTML. */
+  private final SpringTemplateEngine springTemplateEngine;
+
+  /**
+   * Construtor do serviço de e-mail.
+   *
+   * @param repository repositório para persistência de códigos de e-mail
+   * @param sendGrid cliente SendGrid configurado
+   * @param springTemplateEngine motor de templates Thymeleaf
+   */
+  public EmailServiceImpl(
+          EmailCodeRepository repository,
+          SendGrid sendGrid,
+          SpringTemplateEngine springTemplateEngine) {
+    this.repository = repository;
+    this.sendGrid = sendGrid;
+    this.springTemplateEngine = springTemplateEngine;
+  }
+
+  /**
+   * Gera e envia um código de verificação para o e-mail informado, registrando o
+   * código no banco de dados.
+   *
+   * @param email endereço de e-mail do destinatário
+   * @param type tipo do código de verificação
+   * @return resposta da API do SendGrid referente ao envio do e-mail
+   * @throws IllegalArgumentException se tipo for nulo, e-mail inválido ou limites de envio excedidos
+   * @throws IOException se ocorrer falha no envio do e-mail
+   */
+  public Response generateAndSendCode(String email, TipoCodigo type) throws IOException {
+    if (type == null) {
+      throw new IllegalArgumentException("O tipo do código é obrigatório.");
+    }
+    validarEmail(email);
+    verificarLimiteEnvio(email, type);
+
+    String code = gerarCodigoAleatorio();
+    Response response = enviarEmailDeVerificacao(email, code, type);
+    salvarCodigo(email, code, type);
+    return response;
+  }
+
+  /** Valida se o endereço de e-mail fornecido está no formato correto. */
+  private void validarEmail(String email) {
+    if (email == null || !EMAIL_REGEX.matcher(email).matches()) {
+      throw new IllegalArgumentException("Endereço de e-mail inválido.");
+    }
+  }
+
+  /**
+   * Verifica se o envio de códigos para o e-mail excede os limites diário e de curto prazo.
+   *
+   * @param email endereço de e-mail a ser verificado
+   * @param type tipo de código relacionado
+   * @throws IllegalArgumentException se algum limite de envio for atingido
+   */
+  private void verificarLimiteEnvio(String email, TipoCodigo type) {
+    LocalDateTime limiteDiario = LocalDateTime.now().minusHours(24);
+    Long codigos = repository.countByEmailAndTypeAndGeneratedAtAfter(email, type, limiteDiario);
+    if (codigos > MAX_CODES_PER_DAY) {
+      throw new IllegalArgumentException(ERRO_LIMITE_DIARIO);
+    }
+
+    LocalDateTime limiteCurto = LocalDateTime.now().minusMinutes(SHORT_PERIOD_REST_IN_MINUTES);
+    codigos = repository.countByEmailAndTypeAndGeneratedAtAfter(email, type, limiteCurto);
+
+    if (codigos > MAX_CODES_IN_SHORT_PERIOD) {
+      throw new IllegalArgumentException(ERRO_LIMITE_CURTO.formatted(SHORT_PERIOD_REST_IN_MINUTES));
+    }
+  }
+
+  /**
+   * Gera um código aleatório de 4 caracteres alfanuméricos em maiúsculas.
+   *
+   * @return código OTP aleatório
+   */
+  private String gerarCodigoAleatorio() {
+    return UUID.randomUUID().toString().substring(0, 4).toUpperCase();
+  }
+
+  /**
+   * Salva um código de verificação de e-mail no banco de dados com informações de
+   * validade e status.
+   *
+   * @param email endereço de e-mail vinculado ao código
+   * @param code código gerado
+   * @param type tipo de código
+   */
+  private void salvarCodigo(String email, String code, TipoCodigo type) {
+    EmailCode ec = new EmailCode();
+    ec.setEmail(email);
+    ec.setCode(code);
+    ec.setType(type);
+    ec.setGeneratedAt(LocalDateTime.now());
+    ec.setExpiration(LocalDateTime.now().plusMinutes(CODE_EXPIRATION_MINUTES));
+    ec.setUsed(false);
+    repository.save(ec);
+  }
+
+  /**
+   * Envia um e-mail de verificação utilizando template HTML e inclui código e tempo de expiração.
+   *
+   * @param email destinatário
+   * @param code código de verificação
+   * @param type tipo de verificação
+   * @return resposta da API SendGrid
+   * @throws IOException se ocorrer falha ao processar o template ou enviar e-mail
+   */
+  private Response enviarEmailDeVerificacao(String email, String code, TipoCodigo type)
+          throws IOException {
+    String assunto = "Código de Verificação - " + type.getTipo();
+
+    Context context = new Context();
+    context.setVariable("otpCode", code);
+    context.setVariable("expirationMinutes", CODE_EXPIRATION_MINUTES);
+    try {
+      String mensagemHtml = springTemplateEngine.process("otp-template", context);
+      return sendEmail(email, assunto, mensagemHtml, "text/html");
+    } catch (Exception e) {
+      throw new IOException("Erro ao processar o template do e-mail: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Envia um e-mail via SendGrid.
+   *
+   * @param to destinatário
+   * @param subject assunto do e-mail
+   * @param contentText conteúdo (texto ou HTML)
+   * @param tipo tipo do conteúdo ("text/plain" ou "text/html")
+   * @return resposta da API SendGrid
+   * @throws IOException se envio falhar ou status != 202
+   */
+  public Response sendEmail(String to, String subject, String contentText, String tipo)
+          throws IOException {
+    Email from = new Email("webprojeto2@gmail.com");
+    Email toEmail = new Email(to);
+    Content content = new Content(tipo, contentText);
+    Mail mail = new Mail(from, subject, toEmail, content);
+
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("mail/send");
+    request.setBody(mail.build());
+
+    Response response = sendGrid.api(request);
+
+    if (response == null || response.getStatusCode() != 202) {
+      logger.error(
+              "Erro ao enviar e-mail por sendgrid, status code: {}",
+              response != null ? response.getStatusCode() : 0);
+      throw new IOException("Erro ao tentar enviar e-mail, tente novamente mais tarde");
+    }
+
+    return response;
+  }
+}

--- a/src/main/resources/db/migration/V.1.1__create_table_access_code.sql
+++ b/src/main/resources/db/migration/V.1.1__create_table_access_code.sql
@@ -1,0 +1,22 @@
+=====================================================
+
+-- Criação da tabela principal
+CREATE TABLE IF NOT EXISTS tb_access_code (
+                                              id BIGSERIAL PRIMARY KEY, -- Chave primária auto-incrementável
+                                              email VARCHAR(255) NOT NULL, -- E-mail destinatário
+    code VARCHAR(255) NOT NULL UNIQUE, -- Código único
+    generated_at TIMESTAMP NOT NULL, -- Data/hora de geração do código
+    used BOOLEAN NOT NULL DEFAULT FALSE, -- Se já foi utilizado
+    expiration TIMESTAMP NOT NULL, -- Data/hora de expiração
+    type VARCHAR(255) NOT NULL -- Tipo do código: cadastro, recuperação, etc.
+    );
+
+-- Índices adicionais (melhoram buscas por e-mail e tipo)
+CREATE INDEX IF NOT EXISTS idx_tb_access_code_email ON tb_access_code(email);
+CREATE INDEX IF NOT EXISTS idx_tb_access_code_type ON tb_access_code(type);
+
+-- =============================================================
+-- Observações:
+-- - Esta tabela é utilizada para validar ações como cadastro ou recuperação de senha
+-- - A aplicação deve gerenciar a expiração e o uso dos códigos
+-- ============================================================

--- a/src/test/java/utfpr/edu/br/coleta/email/EmailControllerTest.java
+++ b/src/test/java/utfpr/edu/br/coleta/email/EmailControllerTest.java
@@ -1,0 +1,179 @@
+package utfpr.edu.br.coleta.email;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+import utfpr.edu.br.coleta.email.impl.EmailServiceImpl;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/** Testes unitários para EmailController, verificando os retornos de envio e validação.
+ *   Autor: Luiz Alberto dos Passos
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailControllerTest {
+
+  @Mock private EmailServiceImpl emailService;
+
+  @Mock private EmailCodeValidationService validationService;
+
+  @InjectMocks private EmailController controller;
+
+  @BeforeEach
+  void setUp() {}
+
+  /** Teste de envio bem-sucedido. */
+  @Test
+  void testEnviar_Success() throws IOException {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "OTP_CADASTRO";
+
+    when(emailService.generateAndSendCode(email, TipoCodigo.OTP_CADASTRO)).thenReturn(null);
+
+    ResponseEntity<?> response = controller.enviar(email, tipo);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Código enviado com sucesso"));
+  }
+
+  /** Teste de validação de código verdadeiro. */
+  @Test
+  void testValidar_Success() {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "OTP_CADASTRO";
+    String codigo = "ABC123";
+
+    when(validationService.validateCode(email, TipoCodigo.OTP_CADASTRO, codigo)).thenReturn(true);
+
+    ResponseEntity<Boolean> response = controller.validar(email, tipo, codigo);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertTrue(response.getBody());
+  }
+
+  /** Teste de validação de código falso. */
+  @Test
+  void testValidar_CodigoInvalido() {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "OTP_CADASTRO";
+    String codigo = "XYZ999";
+
+    when(validationService.validateCode(email, TipoCodigo.OTP_CADASTRO, codigo)).thenReturn(false);
+
+    ResponseEntity<Boolean> response = controller.validar(email, tipo, codigo);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertFalse(response.getBody());
+  }
+
+  /** Teste de exceção IllegalArgumentException (ex: limite atingido). */
+  @Test
+  void testEnviar_IllegalArgumentException() throws IOException {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "OTP_CADASTRO";
+
+    when(emailService.generateAndSendCode(eq(email), any(TipoCodigo.class)))
+        .thenThrow(new IllegalArgumentException("Limite atingido"));
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> controller.enviar(email, tipo));
+
+    ResponseEntity<?> response = controller.handleIllegalArgumentException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Limite atingido"));
+  }
+
+  /** Teste de exceção IOException (ex: erro na API SendGrid). */
+  @Test
+  void testEnviar_IOException() throws IOException {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "OTP_CADASTRO";
+
+    when(emailService.generateAndSendCode(eq(email), any(TipoCodigo.class)))
+        .thenThrow(new IOException("Erro na API SendGrid"));
+
+    IOException ex = assertThrows(IOException.class, () -> controller.enviar(email, tipo));
+
+    ResponseEntity<?> response = controller.handleIOException(ex);
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Falha ao enviar e-mail"));
+  }
+
+  /** Teste para e-mail inválido (regex falha). */
+  @Test
+  void testEnviar_EmailInvalido() {
+    String email = "email-invalido";
+    String tipo = "OTP_CADASTRO";
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> controller.enviar(email, tipo));
+
+    ResponseEntity<?> response = controller.handleIllegalArgumentException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Email inválido"));
+  }
+
+  /** Teste para tipo de código vazio. */
+  @Test
+  void testEnviar_TipoVazio() {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "";
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> controller.enviar(email, tipo));
+
+    ResponseEntity<?> response = controller.handleIllegalArgumentException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Tipo de código não informado"));
+  }
+
+  /** Teste para e-mail nulo. */
+  @Test
+  void testEnviar_EmailNulo() {
+    String tipo = "OTP_CADASTRO"; // Alterado para corresponder ao nome do enum
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> controller.enviar(null, tipo));
+
+    ResponseEntity<?> response = controller.handleIllegalArgumentException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Email inválido"));
+  }
+
+  /** Teste para tipo nulo. */
+  @Test
+  void testEnviar_TipoNulo() {
+    String email = "teste@utfpr.edu.br";
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> controller.enviar(email, null));
+
+    ResponseEntity<?> response = controller.handleIllegalArgumentException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Tipo de código não informado"));
+  }
+
+  /** Teste para tipo inválido. */
+  @Test
+  void testEnviar_TipoInvalido() {
+    String email = "teste@utfpr.edu.br";
+    String tipo = "TIPO_INEXISTENTE";
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> controller.enviar(email, tipo));
+
+    ResponseEntity<?> response = controller.handleIllegalArgumentException(ex);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertTrue(response.getBody().toString().contains("Tipo de código inválido"));
+  }
+}

--- a/src/test/java/utfpr/edu/br/coleta/email/impl/EmailServiceImplTest.java
+++ b/src/test/java/utfpr/edu/br/coleta/email/impl/EmailServiceImplTest.java
@@ -1,0 +1,149 @@
+package utfpr.edu.br.coleta.email.impl;
+
+
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import utfpr.edu.br.coleta.email.EmailCode;
+import utfpr.edu.br.coleta.email.EmailCodeRepository;
+import utfpr.edu.br.coleta.email.enums.TipoCodigo;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testes unitários para EmailServiceImpl, garantindo que a geração e envio de código funcione
+ * corretamente em diferentes cenários.
+ *  Autor: Luiz Alberto dos Passos
+ */
+@ExtendWith(MockitoExtension.class)
+class EmailServiceImplTest {
+
+  public static final long MAX_DAILY_LIMIT_MAIS_UM = 31L;
+  public static final String ERRO_LIMITE_DIARIO_ATINGIDO =
+      "Quantidade de solicitações ultrapassa o limite das últimas 24 horas.";
+  private static final Long MAX_SHORT_PERIOD_MAIS_UM = 6L;
+  private static final String ERRO_LIMITE_CURTO =
+      "Limite de solicitações atingido, tente novamente em %d minutos.".formatted(15L);
+  @Mock private EmailCodeRepository emailCodeRepository;
+  @Mock private SendGrid sendGrid;
+  @Mock private SpringTemplateEngine springTemplateEngine;
+  @InjectMocks private EmailServiceImpl emailService;
+
+  private String email = "teste@utfpr.edu.br";
+  private TipoCodigo tipo = TipoCodigo.OTP_CADASTRO;
+
+  /** Teste para verificar envio com sucesso. */
+  @Test
+  void testGenerateAndSendCode_Success() throws IOException {
+    when(emailCodeRepository.countByEmailAndTypeAndGeneratedAtAfter(any(), any(), any()))
+        .thenReturn(0L);
+    when(sendGrid.api(any())).thenReturn(new Response(202, "", null));
+    when(springTemplateEngine.process(anyString(), any())).thenReturn("<html>Email content</html>");
+
+    Response response = emailService.generateAndSendCode(email, tipo);
+
+    assertEquals(202, response.getStatusCode());
+
+    ArgumentCaptor<EmailCode> codeCaptor = ArgumentCaptor.forClass(EmailCode.class);
+    verify(emailCodeRepository).save(codeCaptor.capture());
+
+    EmailCode savedCode = codeCaptor.getValue();
+    assertEquals(email, savedCode.getEmail());
+    assertEquals(tipo, savedCode.getType());
+    assertNotNull(savedCode.getCode());
+    assertFalse(savedCode.isUsed());
+    assertNotNull(savedCode.getGeneratedAt());
+    assertNotNull(savedCode.getExpiration());
+    assertFalse(savedCode.getCode().isEmpty());
+    assertTrue(savedCode.getExpiration().isAfter(savedCode.getGeneratedAt()));
+    assertTrue(savedCode.getExpiration().isAfter(LocalDateTime.now()));
+  }
+
+  /** Teste para validar que o limite de envio diário é respeitado. */
+  @Test
+  void testGenerateAndSendCode_MaxDailyLimitReached() {
+    when(emailCodeRepository.countByEmailAndTypeAndGeneratedAtAfter(any(), eq(tipo), any()))
+        .thenReturn(MAX_DAILY_LIMIT_MAIS_UM);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> emailService.generateAndSendCode(email, tipo));
+
+    assertEquals(ERRO_LIMITE_DIARIO_ATINGIDO, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("Valida que o serviço gera erro ao ultrapassar o limite curto de envios")
+  void generateAndSendCode_WhenLimiteCurtoFoiUltrapassado_ReturnErroLimiteCurto() {
+    when(emailCodeRepository.countByEmailAndTypeAndGeneratedAtAfter(any(), eq(tipo), any()))
+        .thenReturn(
+            0L,
+            MAX_SHORT_PERIOD_MAIS_UM); // Primeira chamada para limite diário, segunda para limite
+    // curto
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> emailService.generateAndSendCode(email, tipo));
+    assertEquals(ERRO_LIMITE_CURTO, ex.getMessage());
+  }
+
+  @Test
+  void generateAndSendCode_WhenSendGridResponseIsNull_ReturnIllegalArgumentException() {
+    when(emailCodeRepository.countByEmailAndTypeAndGeneratedAtAfter(any(), any(), any()))
+        .thenReturn(0L);
+    when(springTemplateEngine.process(anyString(), any()))
+        .thenThrow(
+            new RuntimeException("Erro ao tentar enviar e-mail, tente novamente mais tarde"));
+
+    IOException ex =
+        assertThrows(IOException.class, () -> emailService.generateAndSendCode(email, tipo));
+    assertEquals(
+        "Erro ao processar o template do e-mail: Erro ao tentar enviar e-mail, tente novamente mais tarde",
+        ex.getMessage());
+  }
+
+  /** Teste para simular falha no envio pelo SendGrid. */
+  @Test
+  void testGenerateAndSendCode_SendGridFails() throws IOException {
+    when(emailCodeRepository.countByEmailAndTypeAndGeneratedAtAfter(any(), any(), any()))
+        .thenReturn(0L);
+    when(sendGrid.api(any())).thenReturn(new Response(400, "Bad Request", null));
+    when(springTemplateEngine.process(anyString(), any())).thenReturn("<html>Email content</html>");
+
+    IOException ex =
+        assertThrows(IOException.class, () -> emailService.generateAndSendCode(email, tipo));
+
+    assertTrue(ex.getMessage().contains("Erro ao tentar enviar e-mail"));
+  }
+
+  /** Teste para e-mail inválido (regex não passa). */
+  @Test
+  void testGenerateAndSendCode_InvalidEmail() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> emailService.generateAndSendCode("email_invalido", tipo));
+
+    assertEquals("Endereço de e-mail inválido.", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("Garante que erro é retornado no caso de não haver o tipo do código na solicitação")
+  void testGenerateAndSendSendCode_whenTypeIsNull_ShouldReturnIllegalArgumentException() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> emailService.generateAndSendCode(email, null));
+    assertEquals("O tipo do código é obrigatório.", ex.getMessage());
+  }
+}


### PR DESCRIPTION
🔑 Descrição

Este PR implementa o CRUD de Códigos de E-mail (OTP) para autenticação de administradores, incluindo:
	•	Integração com SendGrid para envio de códigos por e-mail.
	•	Validação de formato de e-mail e limites de envio (diário e curto período).
	•	Geração de códigos OTP aleatórios com expiração configurável.
	•	Registro dos códigos no banco de dados com status de uso e data de expiração.
	•	DTO (EmailCodeDto) para transferência de dados.
	•	Serviço de validação (EmailCodeValidationService) para confirmar OTP.
	•	Controller (EmailController) com endpoints de envio e validação.
	•	Tratamento de exceções para parâmetros inválidos e falhas de envio.
	•	Testes unitários abrangentes para o serviço (EmailServiceImplTest).

⸻

🔧 Alterações Principais
	•	EmailCode.java → Entidade JPA para persistência de códigos OTP.
	•	EmailCodeDto.java → DTO com validações.
	•	EmailCodeRepository.java → Queries customizadas para OTP (busca, contagem, validação).
	•	EmailServiceImpl.java → Geração, envio e persistência de códigos OTP.
	•	EmailCodeValidationService.java → Validação de código OTP mais recente.
	•	EmailController.java → Endpoints REST:
	•	POST /api/email/enviar → envia código por e-mail.
	•	POST /api/email/validar → valida código recebido.
	•	EmailConfig.java → Configuração do cliente SendGrid.
	•	EmailServiceImplTest.java → Testes unitários cobrindo cenários de sucesso, erro e limites.

📊 Testes
	•	Executados testes unitários com JUnit 5 + Mockito:
	•	✅ Envio de e-mail com sucesso.
	•	✅ Respeito aos limites de envio diário e curto.
	•	✅ E-mail inválido retorna exceção.
	•	✅ Falha no template ou SendGrid retorna exceção tratada.
	•	✅ Validação de código OTP com marcação como usado.


🔒 Observações
	•	Necessário definir a API Key do SendGrid em variáveis de ambiente (spring.sendgrid.api-key).