### PR TITLE
feat: adicionar endpoint para listar rotas compatíveis por caminhão

### DIFF
--- a/src/main/java/utfpr/edu/br/coleta/caminhao/CaminhaoController.java
+++ b/src/main/java/utfpr/edu/br/coleta/caminhao/CaminhaoController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import utfpr.edu.br.coleta.generics.CrudController;
 import utfpr.edu.br.coleta.motorista.MotoristaDTO;
 import utfpr.edu.br.coleta.motorista.MotoristaService;
+import utfpr.edu.br.coleta.rota.dto.RotaDTO;
 
 import java.util.List;
 
@@ -68,6 +69,34 @@ public class CaminhaoController extends CrudController<Caminhao, CaminhaoDTO> {
     public List<MotoristaDTO> listarMotoristasCompativeis(@PathVariable Long id) {
         return motoristaService.listarMotoristasCompativeis(id).stream()
                 .map(m -> modelMapper.map(m, MotoristaDTO.class))
+                .toList();
+    }
+
+    /**
+     * Retorna as rotas compatíveis com o caminhão informado.
+     *
+     * A compatibilidade é determinada pelo tipo de coleta e pelo tipo
+     * de resíduo definidos no caminhão e na rota. Apenas rotas ativas
+     * e totalmente compatíveis são retornadas.
+     *
+     * Este endpoint é utilizado pelo sistema administrativo para
+     * organizar a logística e evitar incompatibilidades de operação.
+     *
+     * @param id ID do caminhão
+     * @return lista de rotas compatíveis com o caminhão
+     */
+    @Operation(
+            summary = "Lista rotas compatíveis com o caminhão",
+            description = "Retorna somente rotas ativas cujo tipo de coleta e tipo de resíduo são compatíveis com o caminhão fornecido."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Caminhão não encontrado")
+    })
+    @GetMapping("/{id}/rotas-compativeis")
+    public List<RotaDTO> listarRotasCompativeis(@PathVariable Long id) {
+        return service.listarRotasCompativeis(id).stream()
+                .map(rota -> modelMapper.map(rota, RotaDTO.class))
                 .toList();
     }
 }

--- a/src/main/java/utfpr/edu/br/coleta/caminhao/CaminhaoService.java
+++ b/src/main/java/utfpr/edu/br/coleta/caminhao/CaminhaoService.java
@@ -1,6 +1,24 @@
 package utfpr.edu.br.coleta.caminhao;
 
 import utfpr.edu.br.coleta.generics.ICrudService;
+import utfpr.edu.br.coleta.rota.Rota;
 
+import java.util.List;
+
+/**
+ * Serviço de regras de negócio para Caminhão.
+ *
+ * Estende a interface genérica de CRUD e define
+ * operações específicas de caminhão.
+ */
 public interface CaminhaoService extends ICrudService<Caminhao, Long> {
+
+    /**
+     * Lista as rotas compatíveis com o caminhão informado,
+     * considerando tipo de coleta e tipo de resíduo.
+     *
+     * @param caminhaoId ID do caminhão
+     * @return lista de rotas compatíveis
+     */
+    List<Rota> listarRotasCompativeis(Long caminhaoId);
 }

--- a/src/main/java/utfpr/edu/br/coleta/rota/validator/RotaCaminhaoValidator.java
+++ b/src/main/java/utfpr/edu/br/coleta/rota/validator/RotaCaminhaoValidator.java
@@ -1,0 +1,87 @@
+package utfpr.edu.br.coleta.rota.validator;
+
+import org.springframework.stereotype.Component;
+import utfpr.edu.br.coleta.caminhao.Caminhao;
+import utfpr.edu.br.coleta.rota.Rota;
+
+/**
+ * Validador responsável por verificar se um caminhão
+ * pode atender uma determinada rota, com base no tipo
+ * de coleta e no tipo de resíduo.
+ */
+@Component
+public class RotaCaminhaoValidator {
+
+    /**
+     * Valida se um caminhão pode atender uma rota.
+     *
+     * @param caminhao caminhão a ser validado
+     * @param rota rota a ser validada
+     */
+    public void validar(Caminhao caminhao, Rota rota) {
+
+        if (caminhao == null) {
+            throw new IllegalArgumentException("Caminhão não pode ser nulo.");
+        }
+
+        if (rota == null) {
+            throw new IllegalArgumentException("Rota não pode ser nula.");
+        }
+
+        if (!Boolean.TRUE.equals(caminhao.getAtivo())) {
+            throw new IllegalArgumentException(
+                    String.format("Caminhão %s (placa %s) está inativo e não pode ser associado a rotas.",
+                            caminhao.getModelo(), caminhao.getPlaca())
+            );
+        }
+
+        if (!Boolean.TRUE.equals(rota.getAtivo())) {
+            throw new IllegalArgumentException(
+                    String.format("Rota %s está inativa e não pode ser atribuída a caminhões.",
+                            rota.getNome())
+            );
+        }
+
+        // Tipo de coleta deve ser igual
+        if (caminhao.getTipoColeta() == null || rota.getTipoColeta() == null) {
+            throw new IllegalArgumentException("Tipo de coleta deve estar definido para caminhão e rota.");
+        }
+
+        if (!caminhao.getTipoColeta().equals(rota.getTipoColeta())) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Caminhão %s não é compatível com o tipo de coleta da rota %s.",
+                            caminhao.getPlaca(), rota.getNome()
+                    )
+            );
+        }
+
+        // Tipo de resíduo deve ser igual
+        if (caminhao.getResiduo() == null || rota.getTipoResiduo() == null) {
+            throw new IllegalArgumentException("Tipo de resíduo deve estar definido para caminhão e rota.");
+        }
+
+        if (!caminhao.getResiduo().equals(rota.getTipoResiduo())) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Caminhão %s não é compatível com o tipo de resíduo da rota %s.",
+                            caminhao.getPlaca(), rota.getNome()
+                    )
+            );
+        }
+    }
+
+    /**
+     * Verifica se um caminhão pode atender uma rota (sem lançar exceção).
+     *
+     * @return true se puder atender, false caso contrário
+     */
+    public boolean podeAtender(Caminhao caminhao, Rota rota) {
+        try {
+            validar(caminhao, rota);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
- Criado endpoint GET /caminhoes/{id}/rotas-compativeis
- Adicionada regra de compatibilidade por tipo de coleta e tipo de resíduo
- Implementado método listarRotasCompativeis no service
- Documentado endpoint com Swagger (Operation e ApiResponses)
- Ajustado controller com JavaDoc e padronização